### PR TITLE
Migrate logic away from user.Dockerfile into a bash script. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ ifndef EXEC
 	DOCKER_RUN_FLAGS += -it
 endif
 
+ETC_LOCALTIME := $(realpath /etc/localtime)
+
 # Extra arguments to pass to `docker run` if it is or is not `podman` - these
 # are constructed in a very verbose way to be obvious about why we want to do
 # certain things under regular `docker` vs` podman`
@@ -151,7 +153,7 @@ user_run:
 		--group-add sudo \
 		-v $(HOST_DIR):/host:z \
 		-v $(DOCKER_VOLUME_HOME):/home/$(shell whoami) \
-		-v /etc/localtime:/etc/localtime:ro \
+		-v $(ETC_LOCALTIME):/etc/localtime:ro \
 		$(USER_IMG) $(EXEC)
 
 .PHONY: user_run_l4v
@@ -166,7 +168,7 @@ user_run_l4v:
 		-v $(DOCKER_VOLUME_ISABELLE):/isabelle \
 		--group-add stack \
 		--group-add sudo \
-		-v /etc/localtime:/etc/localtime:ro \
+		-v $(ETC_LOCALTIME):/etc/localtime:ro \
 		-v /tmp/.X11-unix:/tmp/.X11-unix \
 		-e DISPLAY=$(DISPLAY) \
 		$(USER_IMG) $(EXEC)

--- a/README.md
+++ b/README.md
@@ -185,3 +185,12 @@ Running Docker on your machine has its own security risks which you should be aw
 Of particular note in this case, your UID and GID are being baked into an image. Any other user on the host who is part of the docker group could spawn a separate container of this image, and hence have read and write access to your files. Of course, if they are part of the docker group, they could do this anyway, but it just makes it a bit easier.
 
 Use at your own risk.
+
+
+## Released images on DockerHub
+
+The Trustworthy Systems group pushes "known working" images to DockerHub under the `trustworthysystems/` DockerHub organisation. Images with the `:latest` tag are the ones currently in use in the Trustworthy Systems regression system, and so are considered to be "known working". Furthermore, each time an image is pushed out, it is tagged with a YYYY_MM_DD formatted date.
+
+To ensure (fairly) reproducible builds of docker images, the images are built using Debian Snapshot (an apt repository that can be pinned to a date in time). When changes are made to the scripts or Dockerfiles in this repo, they are built against a "known working" date of Debian Snapshot - in other words, a date in which we were able to build all the Docker images, and they passed all of our tests. This avoids issues where something in Debian Testing or Unstable has changed and causes apt conflicts, or a newer version breaks the seL4 build process.
+
+Internally, the Trustworthy Systems regression system will, once a week, attempt to build the docker images using regular apt (not using Snapshot), and if successful, will update the "known working" date. This means on the next build of the docker images that gets pushed out will be using this bumped Snapshot date. Typically, the further in time we get from a Debian release, the more packages we need to fetch from Testing or Unstable, and as such, the less likely this automatic bumping is to work, due to above mentioned issues. With some human intervention, it can usually be fixed up fairly easily. However, even without intervention, the "known working" images will continue to function and build.

--- a/dockerfiles/user.Dockerfile
+++ b/dockerfiles/user.Dockerfile
@@ -14,45 +14,9 @@ ARG UNAME
 ARG GID
 ARG GROUP
 
-# Crammed a lot in here to make building the image faster
-# Notes:
-#  - We add the ARG group to the docker image, but if it already exists
-#    we need to change the gID to match the host, which is done via the
-#    groupmod command
-# hadolint ignore=SC2016
-RUN groupadd -fg "${GID}" "${GROUP}" \
-    && groupmod -g "${GID}" "${GROUP}" \
-    && useradd -u "${UID}" -g "${GID}" "${UNAME}" \
-    && passwd -d "${UNAME}" \
-    && echo 'Defaults        lecture_file = /etc/sudoers.lecture' >> /etc/sudoers \
-    && echo 'Defaults        lecture = always' >> /etc/sudoers \
-    && echo '##################### Warning! #####################################' > /etc/sudoers.lecture \
-    && echo 'This is an ephemeral docker container! You can do things to it using' >> /etc/sudoers.lecture \
-    && echo 'sudo, but when you exit, changes made outside of the /host directory' >> /etc/sudoers.lecture \
-    && echo 'will be lost.' >> /etc/sudoers.lecture \
-    && echo 'If you want your changes to be permanent, add them to the ' >> /etc/sudoers.lecture \
-    && echo '    extras.dockerfile' >> /etc/sudoers.lecture \
-    && echo 'in the seL4-CAmkES-L4v dockerfiles repo.' >> /etc/sudoers.lecture \
-    && echo '####################################################################' >> /etc/sudoers.lecture \
-    && echo '' >> /etc/sudoers.lecture \
-    && mkdir "/home/${UNAME}" \
-    && echo 'echo "___                                   "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo " |   _      _ |_      _   _ |_ |_     "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo " |  |  |_| _) |_ \)/ (_) |  |_ | ) \/ "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo "                                   /  "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo " __                                   "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo "(_      _ |_  _  _   _                "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo "__) \/ _) |_ (- ||| _)                "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo "    /                                 "' >> "/home/${UNAME}/.bashrc" \
-    && echo 'echo "Hello, welcome to the sel4/CAmkES/L4v docker build environment"' >> "/home/${UNAME}/.bashrc" \
-    && grep export /root/.bashrc >> "/home/${UNAME}/.bashrc" \
-    && echo 'export PATH=/scripts/repo:$PATH' >> "/home/${UNAME}/.bashrc" \
-    && echo 'cd /host' >> "/home/${UNAME}/.bashrc" \
-    && mkdir -p /isabelle \
-    && chown -R "${UNAME}":"${GROUP}" /isabelle \
-    && ln -s /isabelle "/home/${UNAME}/.isabelle" \
-    && chown -R "${UNAME}":"${GROUP}" "/home/${UNAME}" \
-    && chmod -R ug+rw "/home/${UNAME}"
+COPY scripts/utils/user.sh /tmp/
+
+RUN /bin/bash /tmp/user.sh
 
 VOLUME /home/${UNAME}
 VOLUME /isabelle

--- a/scripts/l4v.sh
+++ b/scripts/l4v.sh
@@ -79,7 +79,8 @@ if [ "$MAKE_CACHES" = "yes" ] ; then
     popd
 
     # We need to fetch some additional components, so that both Isabelle2019 and 2020 have cached dependencies.
-    ISABELLE_COMPONENT_REPOSITORY=$(set +u; source $ISABELLE_SETTINGS_LOCATION; echo "$ISABELLE_COMPONENT_REPOSITORY")
+    # shellcheck disable=SC1090
+    ISABELLE_COMPONENT_REPOSITORY=$(set +u; source "$ISABELLE_SETTINGS_LOCATION"; echo "$ISABELLE_COMPONENT_REPOSITORY")
     pushd ~/.isabelle/contrib
         for package in "csdp-6.x" \
                        "e-2.0-2" \

--- a/scripts/utils/user.sh
+++ b/scripts/utils/user.sh
@@ -23,9 +23,8 @@ set -exuo pipefail
 groupadd -fg "${GID}" "${GROUP}" || true
 groupmod -g "${GID}" "${GROUP}" || true
 
-group_info=$(getent group "$GROUP")
-group_info=(${group_info//:/ })
-
+# Split the group info into an array
+IFS=":" read -r -a group_info <<< "$(getent group "$GROUP")"
 fgroup="${group_info[0]}"
 fgid="${group_info[2]}"
 
@@ -85,6 +84,7 @@ EOF
 mkdir "/home/${UNAME}"
 
 # Put in some branding
+# shellcheck disable=SC2129
 cat << EOF >> "/home/${UNAME}/.bashrc"
 echo '___                                   '
 echo ' |   _      _ |_      _   _ |_ |_     '

--- a/scripts/utils/user.sh
+++ b/scripts/utils/user.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Copyright 2020, Data61/CSIRO
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -exuo pipefail
+
+####################################################################
+# Setup user and groups for inside the container
+
+# It seems that clashes with group names or GIDs is more common
+# than one might think. Here we attempt to make a matching group
+# inside the container, but if it fails, we abandon the attempt.
+
+# Try to create the group to match the GID. If a group already exists
+# with that name, but a different GID, no change will be made.
+# We therefore run groupmod to ensure the GID does match what was
+# requested.
+# However, either of these steps could fail - but if they do,
+# that's OK.
+groupadd -fg "${GID}" "${GROUP}" || true
+groupmod -g "${GID}" "${GROUP}" || true
+
+group_info=$(getent group "$GROUP")
+group_info=(${group_info//:/ })
+
+fgroup="${group_info[0]}"
+fgid="${group_info[2]}"
+
+GROUP_OK=false
+if [ "$fgroup" == "$GROUP" ] && [ "$fgid" == "$GID" ] ; then
+    # This means the group creation has gone OK, so make a user
+    # with the corresponding group
+    GROUP_OK=true
+fi
+
+if [ "$GROUP_OK" = true ]; then
+    useradd -u "${UID}" -g "${GID}" "${UNAME}"
+else
+    # If creating the group didn't work well, that's OK, just
+    # make the user without the same group as the host. Not as
+    # nice, but still works fine.
+    useradd -u "${UID}" "${UNAME}"
+fi
+
+# Remove the user's password
+passwd -d "${UNAME}"
+
+
+####################################################################
+# Setup sudo for inside the container
+
+# Whenever someone uses sudo, be annoying and remind them that
+# it won't be permanent
+cat << EOF >> /etc/sudoers
+Defaults        lecture_file = /etc/sudoers.lecture
+Defaults        lecture = always
+EOF
+
+cat << EOF > /etc/sudoers.lecture
+##################### Warning! #####################################
+This is an ephemeral docker container! You can do things to it using
+sudo, but when you exit, changes made outside of the /host directory
+will be lost.
+If you want your changes to be permanent, add them to the
+    extras.dockerfile
+in the seL4-CAmkES-L4v dockerfiles repo.
+####################################################################
+
+EOF
+
+
+####################################################################
+# Setup home dir
+
+# NOTE: the user's home directory is stored in a docker volume.
+#       (normally called $UNAME_home on the host)
+#       That implies that these instructions will only run if said
+#       docker volume does not exist. Therefore, if the below
+#       changes, users will only see the effect if they run:
+#          docker volume rm $USER_home
+
+mkdir "/home/${UNAME}"
+
+# Put in some branding
+cat << EOF >> "/home/${UNAME}/.bashrc"
+echo '___                                   '
+echo ' |   _      _ |_      _   _ |_ |_     '
+echo ' |  |  |_| _) |_ \)/ (_) |  |_ | ) \/ '
+echo '                                   /  '
+echo ' __                                   '
+echo '(_      _ |_  _  _   _                '
+echo '__) \/ _) |_ (- ||| _)                '
+echo '    /                                 '
+echo 'Hello, welcome to the seL4/CAmkES/L4v docker build environment'
+EOF
+
+# This is a small hack. When the dockerfiles are building, many of
+# the env things are set into the .bashrc of root (since they're
+# building as the root user). Here we just copy all those declarations
+# and put them in this user's .bashrc.
+# This can be an issue with regard to the NOTE above, about docker
+# volumes.
+grep "export" /root/.bashrc >> "/home/${UNAME}/.bashrc"
+
+# Note that this block does not do parameter expansion, so will be
+# copied verbatim into the user's .bashrc.
+# We use this to ensure they have the repo program in their path,
+# and to ensure they start in the /host dir (aka, their own file
+# path)
+cat << 'EOF' >> "/home/${UNAME}/.bashrc"
+export PATH=/scripts/repo:$PATH
+cd /host
+EOF
+
+# Set an appropriate chown setting, based on if the group setup
+# went OK
+chown_setting="${UNAME}"
+if [ "$GROUP_OK" = true ]; then
+    chown_setting="${UNAME}:${GROUP}"
+fi
+
+# Setup isabelle folder, which sits in a volume too.
+mkdir -p /isabelle
+chown -R "$chown_setting" /isabelle
+# Isabelle expects a home dir folder.
+ln -s /isabelle "/home/${UNAME}/.isabelle"
+
+# Make sure the user owns their home dir
+chown -R "$chown_setting" "/home/${UNAME}"
+chmod -R ug+rw "/home/${UNAME}"


### PR DESCRIPTION
This is much cleaner for reading and linting, and as such, much easier to add logic to.

In this case, more complex logic on group creation has been added. If group creation fails, we now abandon trying to setup the group, which is mostly a nice-to-have.

I also added a small commit to fix https://github.com/SEL4PROJ/seL4-CAmkES-L4v-dockerfiles/issues/16, which was way easier than previous attempts.

Reporting and testing from: @robs-cse, who conveniently has an OSX box to test on :smile: 