### PR TITLE
Allow 'docker' to be manually set to podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-
+# Docker-compatible image tool to use (could also be 'podman')
+DOCKER ?= docker
 DOCKERHUB ?= trustworthysystems/
 
 # Base images
@@ -36,7 +37,7 @@ DOCKER_VOLUME_HOME ?= $(shell whoami)-home
 DOCKER_VOLUME_ISABELLE ?= $(shell whoami)-isabelle
 
 # Extra vars
-DOCKER_BUILD ?= docker build
+DOCKER_BUILD ?= $(DOCKER) build
 DOCKER_FLAGS ?= --force-rm=true
 INTERNAL ?= no
 ifndef EXEC
@@ -48,7 +49,7 @@ endif
 # are constructed in a very verbose way to be obvious about why we want to do
 # certain things under regular `docker` vs` podman`
 # Note that `docker --version` will not say "podman" if symlinked.
-CHECK_DOCKER_IS_PODMAN  := docker --help 2>&1 | grep -q podman
+CHECK_DOCKER_IS_PODMAN  := $(DOCKER) --help 2>&1 | grep -q podman
 IF_DOCKER_IS_PODMAN     := $(CHECK_DOCKER_IS_PODMAN) && echo
 IF_DOCKER_IS_NOT_PODMAN := $(CHECK_DOCKER_IS_PODMAN) || echo
 # If we're not `podman` then we'll use the `-u` and `-g` options to set the
@@ -82,27 +83,27 @@ CAKEML_BASE_DATE ?= 2019_01_13
 #################################################
 .PHONY: pull_sel4_image
 pull_sel4_image:
-	docker pull $(DOCKERHUB)$(SEL4_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(SEL4_IMG)
 
 .PHONY: pull_sel4-riscv_image
 pull_sel4-riscv_image:
-	docker pull $(DOCKERHUB)$(SEL4_RISCV_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(SEL4_RISCV_IMG)
 
 .PHONY: pull_camkes_image
 pull_camkes_image:
-	docker pull $(DOCKERHUB)$(CAMKES_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(CAMKES_IMG)
 
 .PHONY: pull_camkes-riscv_image
 pull_camkes_image-riscv:
-	docker pull $(DOCKERHUB)$(CAMKES_RISCV_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(CAMKES_RISCV_IMG)
 
 .PHONY: pull_l4v_image
 pull_l4v_image:
-	docker pull $(DOCKERHUB)$(L4V_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(L4V_IMG)
 
 .PHONY: pull_l4v-riscv_image
 pull_l4v_image-riscv:
-	docker pull $(DOCKERHUB)$(L4V_RISCV_IMG)
+	$(DOCKER) pull $(DOCKERHUB)$(L4V_RISCV_IMG)
 
 .PHONY: pull_images_from_dockerhub
 pull_images_from_dockerhub: pull_sel4_image pull_camkes_image pull_l4v_image
@@ -135,7 +136,7 @@ user_l4v-riscv: build_user_l4v-riscv user_run_l4v
 
 .PHONY: user_run
 user_run:
-	docker run \
+	$(DOCKER) run \
 		$(DOCKER_RUN_FLAGS) \
 		--hostname in-container \
 		--rm \
@@ -149,7 +150,7 @@ user_run:
 
 .PHONY: user_run_l4v
 user_run_l4v:
-	docker run \
+	$(DOCKER) run \
 		$(DOCKER_RUN_FLAGS) \
 		--hostname in-container \
 		--rm \
@@ -208,25 +209,25 @@ build_user_l4v-riscv: build_user
 
 .PHONY: clean_isabelle
 clean_isabelle:
-	docker volume rm $(DOCKER_VOLUME_ISABELLE)
+	$(DOCKER) volume rm $(DOCKER_VOLUME_ISABELLE)
 
 .PHONY: clean_home_dir
 clean_home_dir:
-	docker volume rm $(DOCKER_VOLUME_HOME)
+	$(DOCKER) volume rm $(DOCKER_VOLUME_HOME)
 
 .PHONY: clean_data
 clean_data: clean_isabelle clean_home_dir
 
 .PHONY: clean_images
 clean_images:
-	-docker rmi $(USER_IMG)
-	-docker rmi extras
-	-docker rmi $(DOCKERHUB)$(L4V_IMG)
-	-docker rmi $(DOCKERHUB)$(CAMKES_IMG)
-	-docker rmi $(DOCKERHUB)$(SEL4_IMG)
-	-docker rmi $(DOCKERHUB)$(SEL4_RISCV_IMG)
-	-docker rmi $(DOCKERHUB)$(CAMKES_RISCV_IMG)
-	-docker rmi $(DOCKERHUB)$(L4V_RISCV_IMG)
+	-$(DOCKER) rmi $(USER_IMG)
+	-$(DOCKER) rmi extras
+	-$(DOCKER) rmi $(DOCKERHUB)$(L4V_IMG)
+	-$(DOCKER) rmi $(DOCKERHUB)$(CAMKES_IMG)
+	-$(DOCKER) rmi $(DOCKERHUB)$(SEL4_IMG)
+	-$(DOCKER) rmi $(DOCKERHUB)$(SEL4_RISCV_IMG)
+	-$(DOCKER) rmi $(DOCKERHUB)$(CAMKES_RISCV_IMG)
+	-$(DOCKER) rmi $(DOCKERHUB)$(L4V_RISCV_IMG)
 
 .PHONY: clean
 clean: clean_data clean_images


### PR DESCRIPTION
For RedHat family linux distributions, podman is easier invoked directly so this allows the 'docker' program to be chosen explicitly when invoking make, e.g., `make DOCKER=podman user`.