### PR TITLE
Explicitly install `ssh`

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,15 +17,10 @@ name: Lint Code Base
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-#############################
-# Start the job on all push #
-#############################
-on:
-  push:
-    branches-ignore: [master]
-    # Remove the line above to run when pushing to master
-  pull_request:
-    branches: [master]
+########################
+# Start the job on PRs #
+########################
+on: [pull_request]
 
 ###############
 # Set the Job #

--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -118,6 +118,7 @@ as_root apt-get install -y --no-install-recommends \
         make \
         python3-dev \
         python3-pip \
+        ssh \
         # end of list
 
 # Install python dependencies for both python 2 & 3


### PR DESCRIPTION
It looks like this is not part of the base dependencies any more, but needed by git and repo etc.
