### PR TITLE
sel4.sh: add setup for building documentation

### DIFF
--- a/dockerfiles/apply-tex.Dockerfile
+++ b/dockerfiles/apply-tex.Dockerfile
@@ -1,0 +1,29 @@
+#
+# Copyright 2020, Data61/CSIRO
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ARG BASE_IMG=trustworthysystems/sel4
+# hadolint ignore=DL3006
+FROM $BASE_IMG
+
+LABEL ORGANISATION="Trustworthy Systems"
+LABEL MAINTAINER="Gerwin Klein <gerwin.klein@proofcraft.systems>"
+
+# ARGS are env vars that are *only available* during the docker build
+# They can be modified at docker build time via '--build-arg VAR="something"'
+ARG SCM
+ARG DESKTOP_MACHINE=no
+ARG USE_DEBIAN_SNAPSHOT=yes
+ARG INTERNAL=no
+ARG MAKE_CACHES=yes
+
+ARG SCRIPT=apply-tex.sh
+
+COPY scripts /tmp/
+
+RUN /bin/bash /tmp/${SCRIPT} \
+    && apt-get clean autoclean \
+    && apt-get autoremove --purge --yes \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/apply-tex.sh
+++ b/scripts/apply-tex.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Install sufficient LaTeX packages to build seL4 reference manual
+# doxygen is already installed in sel4.sh
+
+set -exuo pipefail
+
+# Source common functions
+DIR="${BASH_SOURCE%/*}"
+test -d "$DIR" || DIR=$PWD
+# shellcheck source=utils/common.sh
+. "$DIR/utils/common.sh"
+
+possibly_toggle_apt_snapshot
+
+as_root apt-get update -q
+
+as_root apt-get install -y --no-install-recommends \
+        texlive \
+        texlive-latex-extra \
+        # end of list
+
+possibly_toggle_apt_snapshot
+
+# For some reason this pacakge doesn't work on snapshot:
+as_root apt-get install -y --no-install-recommends \
+        texlive-fonts-extra \
+        # end of list

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -42,6 +42,7 @@ as_root apt-get install -y --no-install-recommends \
     cpio \
     curl \
     device-tree-compiler \
+    doxygen \
     g++-6 \
     g++-6-aarch64-linux-gnu \
     g++-6-arm-linux-gnueabi \


### PR DESCRIPTION
This commit adds doxygen + sufficient LaTeX dependencies to build the seL4 reference manual.

See also the discussion on seL4/ci-actions#65