### PR TITLE
Add basic network troubleshooting tools to the base image

### DIFF
--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -114,11 +114,14 @@ as_root apt-get install -y --no-install-recommends \
         devscripts \
         expect \
         git \
+        iproute2 \
+        iputils-ping \
         jq \
         make \
         python3-dev \
         python3-pip \
         ssh \
+        traceroute \
         # end of list
 
 # Install python dependencies for both python 2 & 3


### PR DESCRIPTION
The container lacks ping / traceroute / ip commands which are useful when debugging network issues. This PR adds them.

Signed-off-by: Thomas Böhm <thomas.boehm@hensoldt-cyber.de>