### PR TITLE
Add python-protobuf3

### DIFF
--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -63,6 +63,7 @@ as_root apt-get install -y --no-install-recommends \
     ninja-build \
     protobuf-compiler \
     python-protobuf \
+    python3-protobuf \
     qemu-system-x86 \
     sloccount \
     u-boot-tools \


### PR DESCRIPTION
The latest nanopb tools now use python3 instead of python2 which causes
some of the Bamboo builds to fail. We leave python-protobuf here as the
sel4test manifest which the dockerfiles test against has not yet updated to
the latest changes which include the newest version of nanopb.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>