### PR TITLE
Delete obsolete clang symlink (instead of updating it to keep strange legacy)

### DIFF
--- a/scripts/camkes.sh
+++ b/scripts/camkes.sh
@@ -99,9 +99,6 @@ as_root chmod -R g+rwx "$STACK_ROOT"
 as_root chmod g+s "$STACK_ROOT"
 echo "export STACK_ROOT=\"$STACK_ROOT\"" >> "$HOME/.bashrc"
 
-# CAmkES is hard coded to look for clang in /opt/clang/
-as_root ln -s /usr/lib/llvm-3.8 /opt/clang
-
 if [ "$MAKE_CACHES" = "yes" ] ; then
     # Get a project that relys on stack, and use it to init the capDL-tool cache \
     # then delete the repo, because we don't need it.


### PR DESCRIPTION
Actually, I wonder if the comment still holds today, that CAmkES has this card-coded. I could not find a a place where this is hard-coded and I've not see any errors with the wrong link either. This symlink came in with 9557742518be15676cac6369e061c83d94315882 from @tcptomato, but neither the commit message nor the PR https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/pull/14 mentions this part of the change. So, do we have to create this link at all? 