### PR TITLE
github: linter action tweaks

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,9 +16,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full git history for comparison with other revisions
       - name: Lint Code Base
-        uses: docker://github/super-linter:v4
+        uses: docker://github/super-linter:slim-v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
- use checkout action v3 as in super-linter docs
- clone with full history, so that diffs work
- use slim image, because we're not using any of the linters
  not present there

This might fix the issues observed in #50 