### PR TITLE
github: update `latest` tag on docker push

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -48,10 +48,23 @@ jobs:
       run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_TOKEN}}
 
     - name: "Push trustworthysystems/sel4"
-      run: docker push trustworthysystems/sel4:${DATE}
+      run: |
+        docker push trustworthysystems/sel4:${DATE}
+        docker tag trustworthysystems/sel4:${DATE} trustworthysystems/sel4:latest
+        docker push trustworthysystems/sel4:latest
     - name: "Push trustworthysystems/camkes"
-      run: docker push trustworthysystems/camkes:${DATE}
+      run: |
+        docker push trustworthysystems/camkes:${DATE}
+        docker tag trustworthysystems/camkes:${DATE} trustworthysystems/camkes:latest
+        docker push trustworthysystems/camkes:latest
     - name: "Push trustworthysystems/camkes-cakeml-cogent-rust"
-      run: docker push trustworthysystems/camkes-cakeml-cogent-rust:${DATE}
+      run: |
+        docker push trustworthysystems/camkes-cakeml-cogent-rust:${DATE}
+        docker tag trustworthysystems/camkes-cakeml-cogent-rust:${DATE} \
+                   trustworthysystems/camkes-cakeml-cogent-rust:latest
+        docker push trustworthysystems/camkes-cakeml-cogent-rust:latest
     - name: "Push trustworthysystems/l4v"
-      run: docker push trustworthysystems/l4v:${DATE}
+      run: |
+        docker push trustworthysystems/l4v:${DATE}
+        docker tag trustworthysystems/l4v:${DATE} trustworthysystems/l4v:latest
+        docker push trustworthysystems/l4v:latest


### PR DESCRIPTION
Had previously assumed the `latest` tag was automatic, but it turns out it is not.
