### PR TITLE
Fix shebang to be more portable

### DIFF
--- a/scripts/utils/check_for_old_docker_imgs.sh
+++ b/scripts/utils/check_for_old_docker_imgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61/CSIRO
 #


### PR DESCRIPTION
On NixOS Linux, `make user` fails with:

```bash
$ make user
scripts/utils/check_for_old_docker_imgs.sh
make: scripts/utils/check_for_old_docker_imgs.sh: No such file or directory
make: *** [Makefile:169: run_checks] Error 127
```

This is due to `scripts/utils/check_for_old_docker_imgs.sh` attempting to run bash as its interpreter using a hardcoded `/bin/bash` path. Unfortunately, this doesn't work on NixOS (as well as some other operating systems) for several reasons, one of them being that bash cannot be installed on `/bin`, by design.

This PR changes the interpreter path (the shebang directive) to this instead:
```bash
#!/usr/bin/env bash
```

This is a more portable way to run a bash script and is also recommended by numerous sources, including various Stack Overflow answers and even mentioned on Wikipedia (under the "Portability" section): https://en.wikipedia.org/wiki/Shebang_(Unix) .
It is also one of the recommended ways to fix this type of issues on NixOS while remaining compatible with other operating systems.