### PR TITLE
github: split build into separate jobs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,15 +10,22 @@ on: [pull_request]
 
 jobs:
   build:
-    name: Docker
+    name: Docker images
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set SNAPSHOT_DATE
-      run: |
-        export SNAPSHOT_DATE=$(basename $(curl -ILs -o /dev/null -w %{url_effective} http://snapshot.debian.org/archive/debian/$(date -u +%Y%m%dT%H%M00Z)/) )
-        echo "SNAPSHOT_DATE=${SNAPSHOT_DATE}" >> $GITHUB_ENV
-    - run: ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b sel4
+    - uses: actions/checkout@v3
+    - run: ./build.sh -v -b sel4
     # the following will also build the plain camkes image:
-    - run: ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b camkes -s cakeml -s cogent -s rust
-    - run: ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b l4v
+    - run: ./build.sh -v -b camkes -s cakeml -s cogent -s rust
+
+  # This needs to rebuild the seL4 and camkes images (apart from cakeml/cogent/rust),
+  # but putting l4v in the same job as the large camkes-cakeml-cogent-rust image
+  # overflows the disk space of the GitHub runner.
+  build-l4v:
+    name: Docker images (l4v)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: ./build.sh -v -b sel4
+    - run: ./build.sh -v -b camkes
+    - run: ./build.sh -v -b l4v

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -16,18 +16,32 @@ on:
     - cron: "3 17 * * 4"
 
 jobs:
+  date:
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.date.outputs.date }}
+      snapshot_date: ${{ steps.date.outputs.snapshot_date }}
+    steps:
+      - name: Get date
+        id: date
+        run: |
+          export SNAPSHOT_DATE=$(basename $(curl -ILs -o /dev/null -w %{url_effective} http://snapshot.debian.org/archive/debian/$(date -u +%Y%m%dT%H%M00Z)/) )
+          echo "snapshot_date=${SNAPSHOT_DATE}" >> $GITHUB_OUTPUT
+          echo "date=$(date '+%Y_%m_%d')" >> $GITHUB_OUTPUT
+
   # There is unfortunately no point in parallelising the build of the different
   # images, because they depend on each other. So sequential is the best we can do.
+  # We still split of the l4v build, because the GitHub runner otherwise runs out of
+  # disk space.
   build:
     name: Docker
     runs-on: ubuntu-latest
+    needs: date
+    env:
+      DATE: ${{ needs.date.outputs.date }}
+      SNAPSHOT_DATE: ${{ needs.date.outputs.snapshot_date }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set SNAPSHOT_DATE
-      run: |
-        export SNAPSHOT_DATE=$(basename $(curl -ILs -o /dev/null -w %{url_effective} http://snapshot.debian.org/archive/debian/$(date -u +%Y%m%dT%H%M00Z)/) )
-        echo "SNAPSHOT_DATE=${SNAPSHOT_DATE}" >> $GITHUB_ENV
-        echo "DATE=$(date '+%Y_%m_%d')" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
     - name: "Build trustworthysystems/sel4"
       run: |
         ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b sel4
@@ -39,10 +53,6 @@ jobs:
        docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${DATE}
        docker tag trustworthysystems/camkes-cakeml-cogent-rust:latest \
                   trustworthysystems/camkes-cakeml-cogent-rust:${DATE}
-    - name: "Build trustworthysystems/l4v"
-      run: |
-        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b l4v
-        docker tag trustworthysystems/l4v:latest trustworthysystems/l4v:${DATE}
 
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
@@ -67,6 +77,27 @@ jobs:
         docker tag trustworthysystems/camkes-cakeml-cogent-rust:${DATE} \
                    trustworthysystems/camkes-cakeml-cogent-rust:latest
         docker push trustworthysystems/camkes-cakeml-cogent-rust:latest
+
+  build-l4v:
+    name: Docker (l4v)
+    runs-on: ubuntu-latest
+    needs: [date, build]
+    env:
+      DATE: ${{ needs.date.outputs.date }}
+      SNAPSHOT_DATE: ${{ needs.date.outputs.snapshot_date }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: "Build trustworthysystems/l4v"
+      run: |
+        docker pull trustworthysystems/camkes:${DATE}
+        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b l4v
+        docker tag trustworthysystems/l4v:latest trustworthysystems/l4v:${DATE}
+
+    - name: Authenticate
+      if: ${{ github.repository_owner == 'seL4' }}
+      run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_TOKEN}}
+
     - name: "Push trustworthysystems/l4v"
       if: ${{ github.repository_owner == 'seL4' }}
       run: |

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -16,10 +16,11 @@ on:
     - cron: "3 17 * * 4"
 
 jobs:
-  date:
+  tag:
     runs-on: ubuntu-latest
+    name: Create tag
     outputs:
-      date: ${{ steps.date.outputs.date }}
+      tag: ${{ steps.date.outputs.tag }}
       snapshot_date: ${{ steps.date.outputs.snapshot_date }}
     steps:
       - name: Get date
@@ -27,7 +28,7 @@ jobs:
         run: |
           export SNAPSHOT_DATE=$(basename $(curl -ILs -o /dev/null -w %{url_effective} http://snapshot.debian.org/archive/debian/$(date -u +%Y%m%dT%H%M00Z)/) )
           echo "snapshot_date=${SNAPSHOT_DATE}" >> $GITHUB_OUTPUT
-          echo "date=$(date '+%Y_%m_%d')" >> $GITHUB_OUTPUT
+          echo "tag=$(date '+%Y_%m_%d')" >> $GITHUB_OUTPUT
 
   # There is unfortunately no point in parallelising the build of the different
   # images, because they depend on each other. So sequential is the best we can do.
@@ -36,23 +37,23 @@ jobs:
   build:
     name: Docker
     runs-on: ubuntu-latest
-    needs: date
+    needs: tag
     env:
-      DATE: ${{ needs.date.outputs.date }}
-      SNAPSHOT_DATE: ${{ needs.date.outputs.snapshot_date }}
+      TAG: ${{ needs.tag.outputs.tag }}
+      SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
     - uses: actions/checkout@v3
     - name: "Build trustworthysystems/sel4"
       run: |
         ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b sel4
-        docker tag trustworthysystems/sel4:latest trustworthysystems/sel4:${DATE}
+        docker tag trustworthysystems/sel4:latest trustworthysystems/sel4:${TAG}
     # the following will also build the plain camkes image:
     - name: "Build trustworthysystems/camkes-cakeml-cogent-rust"
       run: |
        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b camkes -s cakeml -s cogent -s rust
-       docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${DATE}
+       docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${TAG}
        docker tag trustworthysystems/camkes-cakeml-cogent-rust:latest \
-                  trustworthysystems/camkes-cakeml-cogent-rust:${DATE}
+                  trustworthysystems/camkes-cakeml-cogent-rust:${TAG}
 
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
@@ -61,38 +62,38 @@ jobs:
     - name: "Push trustworthysystems/sel4"
       if: ${{ github.repository_owner == 'seL4' }}
       run: |
-        docker push trustworthysystems/sel4:${DATE}
-        docker tag trustworthysystems/sel4:${DATE} trustworthysystems/sel4:latest
+        docker push trustworthysystems/sel4:${TAG}
+        docker tag trustworthysystems/sel4:${TAG} trustworthysystems/sel4:latest
         docker push trustworthysystems/sel4:latest
     - name: "Push trustworthysystems/camkes"
       if: ${{ github.repository_owner == 'seL4' }}
       run: |
-        docker push trustworthysystems/camkes:${DATE}
-        docker tag trustworthysystems/camkes:${DATE} trustworthysystems/camkes:latest
+        docker push trustworthysystems/camkes:${TAG}
+        docker tag trustworthysystems/camkes:${TAG} trustworthysystems/camkes:latest
         docker push trustworthysystems/camkes:latest
     - name: "Push trustworthysystems/camkes-cakeml-cogent-rust"
       if: ${{ github.repository_owner == 'seL4' }}
       run: |
-        docker push trustworthysystems/camkes-cakeml-cogent-rust:${DATE}
-        docker tag trustworthysystems/camkes-cakeml-cogent-rust:${DATE} \
+        docker push trustworthysystems/camkes-cakeml-cogent-rust:${TAG}
+        docker tag trustworthysystems/camkes-cakeml-cogent-rust:${TAG} \
                    trustworthysystems/camkes-cakeml-cogent-rust:latest
         docker push trustworthysystems/camkes-cakeml-cogent-rust:latest
 
   build-l4v:
     name: Docker (l4v)
     runs-on: ubuntu-latest
-    needs: [date, build]
+    needs: [tag, build]
     env:
-      DATE: ${{ needs.date.outputs.date }}
-      SNAPSHOT_DATE: ${{ needs.date.outputs.snapshot_date }}
+      TAG: ${{ needs.tag.outputs.tag }}
+      SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
     - uses: actions/checkout@v3
 
     - name: "Build trustworthysystems/l4v"
       run: |
-        docker pull trustworthysystems/camkes:${DATE}
+        docker pull trustworthysystems/camkes:${TAG}
         ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b l4v
-        docker tag trustworthysystems/l4v:latest trustworthysystems/l4v:${DATE}
+        docker tag trustworthysystems/l4v:latest trustworthysystems/l4v:${TAG}
 
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
@@ -101,6 +102,6 @@ jobs:
     - name: "Push trustworthysystems/l4v"
       if: ${{ github.repository_owner == 'seL4' }}
       run: |
-        docker push trustworthysystems/l4v:${DATE}
-        docker tag trustworthysystems/l4v:${DATE} trustworthysystems/l4v:latest
+        docker push trustworthysystems/l4v:${TAG}
+        docker tag trustworthysystems/l4v:${TAG} trustworthysystems/l4v:latest
         docker push trustworthysystems/l4v:latest


### PR DESCRIPTION
This will hopefully avoid that the underlying GitHub runner runs out of disk space.
