### PR TITLE
base_tools: add xxd

### DIFF
--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -69,6 +69,7 @@ as_root apt-get install -y --no-install-recommends \
 
 as_root apt-get install -y --no-install-recommends \
         bc \
+        xxd \
         ca-certificates \
         devscripts \
         expect \


### PR DESCRIPTION
Seems `xxd` is not installed by default, but this is used in `seL4_tools/elfloader-tool/CMakeLists.txt` when`ElfloaderHashInstructions` is enabled. This feature is rarely used and there is no CI coverage also. But when testing https://github.com/seL4/seL4_tools/pull/160 the container gave me an error that `xxd` is not installed.