### PR TITLE
docker: use -slim base image for debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER ?= docker
 DOCKERHUB ?= trustworthysystems/
 
 # Base images
-DEBIAN_IMG ?= debian:bullseye
+DEBIAN_IMG ?= debian:bullseye-slim
 BASETOOLS_IMG ?= base_tools
 
 # Core images

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ apply_software_to_image()
     shift 4
 
     # NOTE: it's OK to supply docker build-args that aren't requested in the Dockerfile
-
+    # shellcheck disable=SC2086
     $DOCKER_BUILD $DOCKER_FLAGS \
 		--build-arg BASE_BUILDER_IMG="$DOCKERHUB$prebuilt_img" \
 		--build-arg BASE_IMG="$DOCKERHUB$orig_img" \

--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,7 @@ set -ef
 
 # Extra vars
 DOCKER_BUILD="docker build"
+DOCKER_INSPECT="docker inspect"
 DOCKER_FLAGS="--force-rm=true"
 
 # Special variables to be passed through Docker to the build scripts
@@ -69,6 +70,9 @@ build_internal_image()
         -t "$img_name" \
         "$@" \
         .
+
+    echo "Size of $img_name:"
+    $DOCKER_INSPECT -f "{{ .Size }}" "$img_name" | xargs printf "%'d\n"
 }
 
 build_image()
@@ -99,6 +103,9 @@ apply_software_to_image()
 		-t "$DOCKERHUB$new_img" \
         "$@" \
 		.
+
+    echo "Size of $new_img:"
+    $DOCKER_INSPECT -f "{{ .Size }}" "$new_img" | xargs printf "%'d\n"
 }
 ############################################
 

--- a/dockerfiles/base_tools.Dockerfile
+++ b/dockerfiles/base_tools.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-ARG BASE_IMG=debian:bullseye
+ARG BASE_IMG=debian:bullseye-slim
 # hadolint ignore=DL3006
 FROM $BASE_IMG
 LABEL ORGANISATION="Trustworthy Systems"


### PR DESCRIPTION
The hope is to reduce image size. This might need further adjustments to explicitly include packages that were implicit before.