### PR TITLE
update base snapshot date

### DIFF
--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -26,7 +26,7 @@ test -d "$DIR" || DIR=$PWD
 : "${SCM:=https://github.com}"
 
 # Debian Snapshot date
-: "${SNAPSHOT_DATE:=20211208T025308Z}"
+: "${SNAPSHOT_DATE:=20240509T144113Z}"
 
 if [ "$DESKTOP_MACHINE" = "no" ] ; then
 


### PR DESCRIPTION
Update base snapshot date to make manual builds closer to most recent CI. This should not affect CI builds since these set the snapshot date from the command line.

Eventually CI should bump this automatically after successful deployment.