### PR TITLE
Makefile: revert localtime mapping removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ user_run:
 		--group-add sudo \
 		-v $(HOST_DIR):/host:z \
 		-v $(DOCKER_VOLUME_HOME):/home/$(shell whoami) \
+		-v $(ETC_LOCALTIME):/etc/localtime:ro \
 		$(USER_IMG) $(EXEC)
 
 .PHONY: user_run_l4v


### PR DESCRIPTION
Mapping /etc/localtime was removed unintentionally in ef7632ca294.