### PR TITLE
github: authenticate earlier for Mac deployment

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,8 @@ jobs:
     name: Docker images (ARM64)
     runs-on: [self-hosted, macos, ARM64]
     steps:
+    - name: "Unlock MacOS Keychain"
+      run: security unlock-keychain -p ${{secrets.M2_MINI_PWD}}
     - uses: actions/checkout@v4
     # don't use cached images on the self-hosted runner to make sure we are
     # picking up current Debian repo state. The GitHub runners start from

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -87,6 +87,12 @@ jobs:
       TAG: ${{ needs.tag.outputs.tag }}
       SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
+    - name: Authenticate
+      if: ${{ github.repository_owner == 'seL4' }}
+      run: |
+        security unlock-keychain -p ${{secrets.M2_MINI_PWD}}
+        echo ${{secrets.DOCKER_TOKEN}} | docker login -u ${{secrets.DOCKER_USER}} --password-stdin
+
     - uses: actions/checkout@v4
     - name: "Build trustworthysystems/sel4"
       run: |
@@ -99,10 +105,6 @@ jobs:
        docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${TAG}-arm64
        docker tag trustworthysystems/camkes-cakeml-rust:latest \
                   trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
-
-    - name: Authenticate
-      if: ${{ github.repository_owner == 'seL4' }}
-      run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_TOKEN}}
 
     - name: "Push trustworthysystems/sel4"
       if: ${{ github.repository_owner == 'seL4' }}


### PR DESCRIPTION
Authenticate earlier and unlock MacOS keychain so that the rest of the job can access dockerhub.