### PR TITLE
multi-arch: prune old images, fix typo

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -93,6 +93,9 @@ jobs:
         security unlock-keychain -p ${{secrets.M2_MINI_PWD}}
         echo ${{secrets.DOCKER_TOKEN}} | docker login -u ${{secrets.DOCKER_USER}} --password-stdin
 
+    - name: "Remove old images"
+      run: docker system prune -a -f
+
     - uses: actions/checkout@v4
     - name: "Build trustworthysystems/sel4"
       run: |

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -173,28 +173,28 @@ jobs:
         run: |
           docker buildx imagetools create -t trustworthysystems/sel4:${TAG} \
             trustworthysystems/sel4:${TAG}-arm64
-            trustworthysystems/sel4:${TAG}-arm64
+            trustworthysystems/sel4:${TAG}-amd64
 
           docker buildx imagetools create -t trustworthysystems/sel4:latest \
             trustworthysystems/sel4:${TAG}-arm64
-            trustworthysystems/sel4:${TAG}-arm64
+            trustworthysystems/sel4:${TAG}-amd64
 
       - name: "Multi-arch CAmkES"
         run: |
           docker buildx imagetools create -t trustworthysystems/camkes:${TAG} \
             trustworthysystems/camkes:${TAG}-arm64
-            trustworthysystems/camkes:${TAG}-arm64
+            trustworthysystems/camkes:${TAG}-amd64
 
           docker buildx imagetools create -t trustworthysystems/camkes:latest \
             trustworthysystems/camkes:${TAG}-arm64
-            trustworthysystems/camkes:${TAG}-arm64
+            trustworthysystems/camkes:${TAG}-amd64
 
       - name: "Multi-arch CAmkES+CakeML+Rust"
         run: |
           docker buildx imagetools create -t trustworthysystems/camkes-cakeml-rust:${TAG} \
             trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
-            trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
+            trustworthysystems/camkes-cakeml-rust:${TAG}-amd64
 
           docker buildx imagetools create -t trustworthysystems/camkes-cakeml-rust:latest \
             trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
-            trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
+            trustworthysystems/camkes-cakeml-rust:${TAG}-amd64


### PR DESCRIPTION
- prune old images on self-hosted runner to make sure we're not starting from something stale
- fix typos in arm64/amd64