### PR TITLE
camkes: re-add lib32stdc++-10-dev

### DIFF
--- a/scripts/camkes.sh
+++ b/scripts/camkes.sh
@@ -37,6 +37,8 @@ possibly_toggle_apt_snapshot
 as_root dpkg --add-architecture i386
 as_root dpkg --add-architecture arm64
 as_root apt-get update -q
+
+# lib32stdc++-10-dev for 32-bit Linux VMM
 as_root apt-get install -y --no-install-recommends \
     acl \
     fakeroot \
@@ -44,6 +46,7 @@ as_root apt-get install -y --no-install-recommends \
     linux-libc-dev:i386 \
     pkg-config \
     spin \
+    lib32stdc++-10-dev:amd64 \
     # end of list
 
 # Required for testing


### PR DESCRIPTION
ef7632ca29 removed lib32stdc++-10-dev, but it is still needed for the 32bit CamkES Linux VMM.

This should fix #84, although I haven't been able to try it out yet.