### PR TITLE
remove Debian snapshots as default

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -21,13 +21,10 @@ jobs:
     name: Create tag
     outputs:
       tag: ${{ steps.date.outputs.tag }}
-      snapshot_date: ${{ steps.date.outputs.snapshot_date }}
     steps:
       - name: Get date
         id: date
         run: |
-          export SNAPSHOT_DATE=$(basename $(curl -ILs -o /dev/null -w %{url_effective} http://snapshot.debian.org/archive/debian/$(date -u +%Y%m%dT%H%M00Z)/) )
-          echo "snapshot_date=${SNAPSHOT_DATE}" >> $GITHUB_OUTPUT
           echo "tag=$(date '+%Y_%m_%d')" >> $GITHUB_OUTPUT
 
   # There is unfortunately no point in parallelising the build of the different
@@ -40,17 +37,16 @@ jobs:
     needs: tag
     env:
       TAG: ${{ needs.tag.outputs.tag }}
-      SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
     - uses: actions/checkout@v4
     - name: "Build trustworthysystems/sel4"
       run: |
-        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b sel4
+        ./build.sh -v -b sel4
         docker tag trustworthysystems/sel4:latest trustworthysystems/sel4:${TAG}-amd64
     # the following will also build the plain camkes image:
     - name: "Build trustworthysystems/camkes-cakeml-rust"
       run: |
-       ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b camkes -s cakeml -s rust
+       ./build.sh -v -b camkes -s cakeml -s rust
        docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${TAG}-amd64
        docker tag trustworthysystems/camkes-cakeml-rust:latest \
                   trustworthysystems/camkes-cakeml-rust:${TAG}-amd64
@@ -88,7 +84,6 @@ jobs:
     needs: tag
     env:
       TAG: ${{ needs.tag.outputs.tag }}
-      SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
@@ -103,12 +98,12 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Build trustworthysystems/sel4"
       run: |
-        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -vr -b sel4
+        ./build.sh -vr -b sel4
         docker tag trustworthysystems/sel4:latest trustworthysystems/sel4:${TAG}-arm64
     # the following will also build the plain camkes image:
     - name: "Build trustworthysystems/camkes-cakeml-rust"
       run: |
-       ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -vr -b camkes -s cakeml -s rust
+       ./build.sh -vr -b camkes -s cakeml -s rust
        docker tag trustworthysystems/camkes:latest trustworthysystems/camkes:${TAG}-arm64
        docker tag trustworthysystems/camkes-cakeml-rust:latest \
                   trustworthysystems/camkes-cakeml-rust:${TAG}-arm64
@@ -139,7 +134,6 @@ jobs:
     needs: [tag, build-amd64]
     env:
       TAG: ${{ needs.tag.outputs.tag }}
-      SNAPSHOT_DATE: ${{ needs.tag.outputs.snapshot_date }}
     steps:
     - uses: actions/checkout@v4
 
@@ -147,7 +141,7 @@ jobs:
       run: |
         docker pull trustworthysystems/camkes:${TAG}-amd64
         docker tag trustworthysystems/camkes:${TAG}-amd64 trustworthysystems/camkes:latest
-        ./build.sh -e SNAPSHOT_DATE=${SNAPSHOT_DATE} -v -b l4v
+        ./build.sh -v -b l4v
         docker tag trustworthysystems/l4v:latest trustworthysystems/l4v:${TAG}
 
     - name: Authenticate

--- a/README.md
+++ b/README.md
@@ -178,13 +178,10 @@ Use at your own risk.
 
 ## Released images on DockerHub
 
-The seL4 CI pushes "known working" images to DockerHub under the [`trustworthysystems/` DockerHub organisation][1]. Images with the `:latest` tag are the ones currently in use in the seL4 CI system, and so are considered to be "known working". Furthermore, each time an image is pushed out, it is tagged with a `YYYY_MM_DD` formatted date.
-
-To ensure (fairly) reproducible builds of docker images, the images are built using Debian Snapshot (an apt repository that can be pinned to a date in time). When changes are made to the scripts or Docker files in this repo, they are built against a "known working" date of Debian Snapshot - in other words, a date in which we were able to build all the Docker images, and they passed all of our tests. This avoids issues where something in Debian Testing or Unstable has changed and causes apt conflicts, or a newer version breaks the seL4 build process.
-
-<!-- Currently not the case:
-Internally, the seL4 CI system will, once a week, attempt to build the docker images using regular apt (not using Snapshot), and if successful, will update the "known working" date. This means on the next build of the docker images that gets pushed out will be using this bumped Snapshot date. Typically, the further in time we get from a Debian release, the more packages we need to fetch from Testing or Unstable, and as such, the less likely this automatic bumping is to work, due to above mentioned issues. With some human intervention, it can usually be fixed up fairly easily. However, even without intervention, the "known working" images will continue to function and build.
--->
+The seL4 CI pushes "known working" images to DockerHub under the [`trustworthysystems/` DockerHub
+organisation][1], usually once a week. Each time an image is pushed out, it is tagged with a
+`YYYY_MM_DD` formatted date. Images with the `:latest` tag are the ones currently in use in the seL4
+CI system.
 
 [1]: https://hub.docker.com/u/trustworthysystems
 

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -ef
 : "${DOCKERHUB:=trustworthysystems/}"
 
 # Base images
-: "${DEBIAN_IMG:=debian:bullseye-20210816-slim}"
+: "${DEBIAN_IMG:=debian:bullseye-slim}"
 : "${BASETOOLS_IMG:=base_tools}"
 
 # Core images

--- a/dockerfiles/apply-binary_decomp.Dockerfile
+++ b/dockerfiles/apply-binary_decomp.Dockerfile
@@ -16,7 +16,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG MAKE_CACHES=yes
 ARG SMTSOLVERS_DIR="/smtsolvers"
 

--- a/dockerfiles/apply-camkes_vis.Dockerfile
+++ b/dockerfiles/apply-camkes_vis.Dockerfile
@@ -16,7 +16,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG MAKE_CACHES=yes
 
 ARG SCRIPT=apply-camkes_vis.sh

--- a/dockerfiles/apply-tex.Dockerfile
+++ b/dockerfiles/apply-tex.Dockerfile
@@ -16,7 +16,7 @@ LABEL MAINTAINER="Gerwin Klein <gerwin.klein@proofcraft.systems>"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG MAKE_CACHES=yes
 
 ARG SCRIPT=apply-tex.sh

--- a/dockerfiles/base_tools.Dockerfile
+++ b/dockerfiles/base_tools.Dockerfile
@@ -15,7 +15,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG SNAPSHOT_DATE
 ARG MAKE_CACHES=yes
 

--- a/dockerfiles/camkes.Dockerfile
+++ b/dockerfiles/camkes.Dockerfile
@@ -14,7 +14,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 # ARGS are env vars that are *only available* during the docker build
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG DESKTOP_MACHINE=no
 ARG MAKE_CACHES=yes
 ARG STACK_ROOT=/etc/stack

--- a/dockerfiles/l4v.Dockerfile
+++ b/dockerfiles/l4v.Dockerfile
@@ -21,7 +21,7 @@ ENV NEW_ISABELLE_SETTINGS "/tmp/isabelle_settings"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG MAKE_CACHES=yes
 
 COPY scripts /tmp/

--- a/dockerfiles/sel4.Dockerfile
+++ b/dockerfiles/sel4.Dockerfile
@@ -15,7 +15,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 # They can be modified at docker build time via '--build-arg VAR="something"'
 ARG SCM
 ARG DESKTOP_MACHINE=no
-ARG USE_DEBIAN_SNAPSHOT=yes
+ARG USE_DEBIAN_SNAPSHOT
 ARG MAKE_CACHES=yes
 
 ARG SCRIPT=sel4.sh

--- a/scripts/utils/common.sh
+++ b/scripts/utils/common.sh
@@ -14,7 +14,7 @@ set -exuo pipefail
 : "${DEBIAN_FRONTEND:=noninteractive}"
 export DEBIAN_FRONTEND
 
-: "${USE_DEBIAN_SNAPSHOT:=yes}"
+: "${USE_DEBIAN_SNAPSHOT:=no}"
 export USE_DEBIAN_SNAPSHOT
 
 # Common vars


### PR DESCRIPTION
- make not using snapshots the default
- remove snapshots from CI build

While the snapshots in theory make the build more reproducible, the snapshot repos is notoriously unreliable in CI making the build fail more often than it succeeds.

Since we publish and tag the CI builds, if somebody wants to use the exact same base containers, they can use the tagged image -- reproducing the image build from scratch is not necessary for that scenario.