### PR TITLE
Switch to clang-12 as minimum version

### DIFF
--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -85,6 +85,13 @@ as_root apt-get install -y --no-install-recommends \
         traceroute \
         # end of list
 
+# public key for apt.llvm.org
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | as_root apt-key add -
+
+# for specific llvm/clang versions
+echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-12 main" >> /etc/apt/sources.list
+as_root apt-get update -q
+
 # Install python dependencies
 # Upgrade pip first, then install setuptools (required for other pip packages)
 # Install some basic python tools

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -71,7 +71,7 @@ as_root apt-get install -y --no-install-recommends \
     qemu-system-x86 \
     sloccount \
     u-boot-tools \
-    clang-11 \
+    clang-12 \
     g++-10 \
     g++-10-arm-linux-gnueabi \
     g++-10-arm-linux-gnueabihf \
@@ -80,7 +80,7 @@ as_root apt-get install -y --no-install-recommends \
     gcc-10-arm-linux-gnueabihf \
     gcc-10-base \
     gcc-riscv64-unknown-elf \
-    libclang-11-dev \
+    libclang-12-dev \
     qemu-system-arm \
     qemu-system-misc \
     $CROSS
@@ -144,12 +144,12 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
         done
     done
 
-    # Ensure that clang-11 shows up as clang
+    # Ensure that clang-12 shows up as clang
     for compiler in clang \
                     clang++ \
                     # end of list
         do
-            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-11)" 60 && \
+            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-12)" 60 && \
             as_root update-alternatives --auto "$compiler"
     done
     # Do a quick check to make sure it works:


### PR DESCRIPTION
clang-11 is ancient (current is clang-19) and seems to miscompile seL4 in some SMP configurations. Use clang-12 as minimum version instead.

Specifically, the MULTICORE0002 failures on Odroid C4 boards in `ODROID_C4_debug_SMP_MCS_clang_64` configs occur only with clang-11, but not with clang-12, and they do not seem to have any specific cause that is visible in the source.
