### PR TITLE
switch back to clang-11

### DIFF
--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -85,13 +85,6 @@ as_root apt-get install -y --no-install-recommends \
         traceroute \
         # end of list
 
-# public key for apt.llvm.org
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | as_root apt-key add -
-
-# for specific llvm/clang versions
-echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-12 main" >> /etc/apt/sources.list
-as_root apt-get update -q
-
 # Install python dependencies
 # Upgrade pip first, then install setuptools (required for other pip packages)
 # Install some basic python tools

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -71,7 +71,7 @@ as_root apt-get install -y --no-install-recommends \
     qemu-system-x86 \
     sloccount \
     u-boot-tools \
-    clang-12 \
+    clang-11 \
     g++-10 \
     g++-10-arm-linux-gnueabi \
     g++-10-arm-linux-gnueabihf \
@@ -80,7 +80,7 @@ as_root apt-get install -y --no-install-recommends \
     gcc-10-arm-linux-gnueabihf \
     gcc-10-base \
     gcc-riscv64-unknown-elf \
-    libclang-12-dev \
+    libclang-11-dev \
     qemu-system-arm \
     qemu-system-misc \
     $CROSS
@@ -144,12 +144,12 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
         done
     done
 
-    # Ensure that clang-12 shows up as clang
+    # Ensure that clang-11 shows up as clang
     for compiler in clang \
                     clang++ \
                     # end of list
         do
-            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-12)" 60 && \
+            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-11)" 60 && \
             as_root update-alternatives --auto "$compiler"
     done
     # Do a quick check to make sure it works:


### PR DESCRIPTION
The clang-12 experiment did not work out. Not only did it not fix the issue we hoped it would fix, but it also breaks clang RISCV builds, initially because it doesn't find the right `ld`, then because it has trouble with our version of muslibc.

This reverts commit 2c2131ee6da9efb570b93015858696848780b4a6.